### PR TITLE
configuring the database with port 5433

### DIFF
--- a/disscuss/config/dev.exs
+++ b/disscuss/config/dev.exs
@@ -3,8 +3,9 @@ import Config
 # Configure your database
 config :disscuss, Disscuss.Repo,
   username: "postgres",
-  password: "postgres",
+  password: "doyouknow",
   hostname: "localhost",
+  port: "5433",
   database: "disscuss_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,

--- a/disscuss/mix.exs
+++ b/disscuss/mix.exs
@@ -7,7 +7,7 @@ defmodule Disscuss.MixProject do
       version: "0.1.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:gettext] ++ Mix.compilers(),
+      #compilers: [:gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps()
@@ -46,7 +46,7 @@ defmodule Disscuss.MixProject do
       {:swoosh, "~> 1.3"},
       {:telemetry_metrics, "~> 0.6"},
       {:telemetry_poller, "~> 1.0"},
-      {:gettext, "~> 0.18"},
+      {:gettext, "~> 0.20.0"},
       {:jason, "~> 1.2"},
       {:plug_cowboy, "~> 2.5"}
     ]


### PR DESCRIPTION
There was a problem with the configuration of the database:
Postgres version 14 made the default `port 5433` **instead** of `5432 `which made a big problem
fixing the port made everything up and running
![Screenshot 2022-10-10 120705](https://user-images.githubusercontent.com/36204725/194851042-a6fd461f-ec27-4270-a0ce-9c778674ddd7.png)
![Screenshot 2022-10-10 134441](https://user-images.githubusercontent.com/36204725/194851056-ef0a3526-b8e5-47da-a613-32bc99cf0e46.png)
